### PR TITLE
Tasks migration

### DIFF
--- a/server/db/migrations/20220404172703_create_tasks.js
+++ b/server/db/migrations/20220404172703_create_tasks.js
@@ -5,11 +5,11 @@
 exports.up = function (knex) {
     return knex.schema.createTable("tasks", (table) => {
         table.increments("id").primary().unsigned();
-        table.integer("assigner_id");
-        table.integer("assignee_id");
+        table.string("info_type");
+        table.integer("info_id").references("id").inTable(info_type);
+        table.integer("assigner_id").references("user_id").inTable("user_informations");
+        table.integer("assignee_id").references("user_id").inTable("user_informations");
         table.date("due_date");
-        table.integer("info_type");
-        table.integer("info_id");
     });
 };
 

--- a/server/db/migrations/20220404172703_create_tasks.js
+++ b/server/db/migrations/20220404172703_create_tasks.js
@@ -1,0 +1,22 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.createTable("tasks", (table) => {
+        table.increments("id").primary().unsigned();
+        table.integer("assigner_id");
+        table.integer("assignee_id");
+        table.date("due_date");
+        table.integer("info_type");
+        table.integer("info_id");
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    knex.schema.dropTable("tasks");
+};

--- a/server/db/migrations/20220404172703_create_tasks.js
+++ b/server/db/migrations/20220404172703_create_tasks.js
@@ -5,11 +5,13 @@
 exports.up = function (knex) {
     return knex.schema.createTable("tasks", (table) => {
         table.increments("id").primary().unsigned();
-        table.string("info_type");
-        table.integer("info_id").references("id").inTable(info_type);
-        table.integer("assigner_id").references("user_id").inTable("user_informations");
-        table.integer("assignee_id").references("user_id").inTable("user_informations");
-        table.date("due_date");
+        table.string("info_type").notNullable;
+        table.integer("info_id").notNullable();
+        table.integer("assigner_id").notNullable()
+            .references("id").inTable("users").onDelete("CASCADE").onUpdate("CASCADE");
+        table.integer("assignee_id").notNullable()
+            .references("id").inTable("users").onDelete("CASCADE").onUpdate("CASCADE");
+        table.date("due_date").notNullable();
     });
 };
 

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -7,6 +7,12 @@ const bcrypt = require("bcryptjs");
 exports.seed = async function (knex) {
   // Deletes ALL existing entries
   await knex("users").del();
+  await knex("tasks").del();
+
+  await knex("tasks").insert([
+    { assigner_id: "", assignee_id: "", due_date: "", info_type: "", info_id: "" }
+  ]);
+
   await knex("users").insert([
     { email: "ben@email.com", password_digest: bcrypt.hashSync("password") },
     { email: "daniel@email.com", password_digest: bcrypt.hashSync("password") },

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -7,12 +7,6 @@ const bcrypt = require("bcryptjs");
 exports.seed = async function (knex) {
   // Deletes ALL existing entries
   await knex("users").del();
-  await knex("tasks").del();
-
-  //Date format as YYYY-MM-DD
-  await knex("tasks").insert([
-    { assigner_id: 1, assignee_id: 2, due_date: "2022-05-08", info_type: "", info_id: "" }
-  ]);
 
   await knex("users").insert([
     { email: "ben@email.com", password_digest: bcrypt.hashSync("password") },
@@ -26,4 +20,5 @@ exports.seed = async function (knex) {
     { email: "jeet@email.com", password_digest: bcrypt.hashSync("password") },
     { email: "hongxiang@email.com", password_digest: bcrypt.hashSync("password") },
   ]);
+
 };

--- a/server/db/seeds/default.js
+++ b/server/db/seeds/default.js
@@ -9,8 +9,9 @@ exports.seed = async function (knex) {
   await knex("users").del();
   await knex("tasks").del();
 
+  //Date format as YYYY-MM-DD
   await knex("tasks").insert([
-    { assigner_id: "", assignee_id: "", due_date: "", info_type: "", info_id: "" }
+    { assigner_id: 1, assignee_id: 2, due_date: "2022-05-08", info_type: "", info_id: "" }
   ]);
 
   await knex("users").insert([

--- a/server/db/seeds/tasks.js
+++ b/server/db/seeds/tasks.js
@@ -1,0 +1,15 @@
+const bcrypt = require("bcryptjs");
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.seed = async function (knex) {
+    // Deletes ALL existing entries
+    await knex("tasks").del();
+
+    //Date format as YYYY-MM-DD
+    await knex("tasks").insert([
+        { assigner_id: 1, assignee_id: 2, due_date: "2022-05-08", info_type: "time_off_requests", info_id: 1 }
+    ]);
+}


### PR DESCRIPTION
Created a separate seed for tasks to ensure that they execute alphabetically and no foreign key violations occur since tasks references users. 

I also noticed that having run the program a few times, the `users.id` field did not reset (the first batch was 1-10, the second 11-20, and so on). So if you are encountering foreign key violations roll back the migrations (using `npx knex migrate:down` worked for me) or manually delete the tables (or just change the value of `assigner_id` and` assignee_id` to be in range).